### PR TITLE
Port codebase to Rust 2018 edition.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/falconre/falcon"
 description = "A Binary Analysis Framework in Rust"
 license = "Apache-2.0"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 base64 = "0.9"

--- a/lib/analysis/calling_convention.rs
+++ b/lib/analysis/calling_convention.rs
@@ -1,6 +1,6 @@
 //! Information about varying calling conventions.
 
-use il;
+use crate::il;
 use std::collections::HashSet;
 
 /// Available type of calling conventions

--- a/lib/analysis/constants.rs
+++ b/lib/analysis/constants.rs
@@ -6,10 +6,10 @@
 //! Calling Constants::eval() uses the known constant values to replace scalars,
 //! and then attempts to evaluate the expression to an `il::Constant`.
 
-use analysis::fixed_point;
-use error::*;
-use executor::eval;
-use il;
+use crate::analysis::fixed_point;
+use crate::error::*;
+use crate::executor::eval;
+use crate::il;
 use std::cmp::{Ordering, PartialOrd};
 use std::collections::HashMap;
 

--- a/lib/analysis/dead_code_elimination.rs
+++ b/lib/analysis/dead_code_elimination.rs
@@ -1,8 +1,8 @@
 //! Dead-Code Elimination
 
-use analysis::{def_use, reaching_definitions};
-use error::*;
-use il;
+use crate::analysis::{def_use, reaching_definitions};
+use crate::error::*;
+use crate::il;
 use std::collections::HashSet;
 
 #[allow(dead_code)]

--- a/lib/analysis/def_use.rs
+++ b/lib/analysis/def_use.rs
@@ -1,8 +1,8 @@
 //! Definition Use Analysis
 
-use analysis::{reaching_definitions, LocationSet};
-use error::*;
-use il;
+use crate::analysis::{reaching_definitions, LocationSet};
+use crate::error::*;
+use crate::il;
 use std::collections::HashMap;
 
 #[allow(dead_code)]

--- a/lib/analysis/fixed_point.rs
+++ b/lib/analysis/fixed_point.rs
@@ -1,7 +1,7 @@
 //! A fixed-point engine for data-flow analysis.
 
-use error::*;
-use il;
+use crate::error::*;
+use crate::il;
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 

--- a/lib/analysis/location_set.rs
+++ b/lib/analysis/location_set.rs
@@ -1,5 +1,5 @@
 /// A Partially-Ordered set of program locations for data-flow analysis.
-use il;
+use crate::il;
 use std::cmp::{Ordering, PartialEq, PartialOrd};
 use std::collections::HashSet;
 

--- a/lib/analysis/reaching_definitions.rs
+++ b/lib/analysis/reaching_definitions.rs
@@ -1,6 +1,6 @@
-use analysis::{fixed_point, LocationSet};
-use error::*;
-use il;
+use crate::analysis::{fixed_point, LocationSet};
+use crate::error::*;
+use crate::il;
 use std::collections::HashMap;
 
 /// Compute reaching definitions for the given function.

--- a/lib/analysis/stack_pointer_offsets.rs
+++ b/lib/analysis/stack_pointer_offsets.rs
@@ -6,11 +6,11 @@
 //! This analysis works off a very simple lattice, Top/Value/Bottom, where Value
 //! is an isize.
 
-use analysis::fixed_point;
-use architecture::Architecture;
-use error::*;
-use executor::eval;
-use il;
+use crate::analysis::fixed_point;
+use crate::architecture::Architecture;
+use crate::error::*;
+use crate::executor::eval;
+use crate::il;
 use std::cmp::{Ordering, PartialOrd};
 use std::collections::HashMap;
 

--- a/lib/analysis/use_def.rs
+++ b/lib/analysis/use_def.rs
@@ -1,6 +1,6 @@
-use analysis::{reaching_definitions, LocationSet};
-use error::*;
-use il;
+use crate::analysis::{reaching_definitions, LocationSet};
+use crate::error::*;
+use crate::il;
 use std::collections::HashMap;
 
 #[allow(dead_code)]

--- a/lib/architecture.rs
+++ b/lib/architecture.rs
@@ -1,9 +1,9 @@
 //! Information and types for Falcon's supported architectures.
 
-use analysis::calling_convention::{CallingConvention, CallingConventionType};
-use il;
+use crate::analysis::calling_convention::{CallingConvention, CallingConventionType};
+use crate::il;
+use crate::translator;
 use std::fmt::Debug;
-use translator;
 
 /// An architecture's endanness.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/lib/executor/driver.rs
+++ b/lib/executor/driver.rs
@@ -1,11 +1,11 @@
 //! A driver concretely executes a Falcon IL programs.
 
-use architecture::Architecture;
-use error::*;
-use executor::successor::*;
-use executor::State;
-use il;
-use RC;
+use crate::architecture::Architecture;
+use crate::error::*;
+use crate::executor::successor::*;
+use crate::executor::State;
+use crate::il;
+use crate::RC;
 
 /// A driver for a concrete executor over Falcon IL.
 #[derive(Debug, Clone)]

--- a/lib/executor/eval.rs
+++ b/lib/executor/eval.rs
@@ -1,5 +1,5 @@
-use error::*;
-use il;
+use crate::error::*;
+use crate::il;
 
 /// Evaluate an `il::Expression` where all terminals are `il::Constant`, and
 /// return the resulting `il::Constant`.

--- a/lib/executor/mod.rs
+++ b/lib/executor/mod.rs
@@ -1,8 +1,8 @@
 //! Concrete execution over Falcon IL.
 
-use error::*;
-use il;
-use memory;
+use crate::error::*;
+use crate::il;
+use crate::memory;
 
 mod driver;
 mod eval;
@@ -17,8 +17,8 @@ pub use self::successor::*;
 /// A `falcon::memory::paged::Memory` over `il::Constant`.
 pub type Memory = memory::paged::Memory<il::Constant>;
 
-use memory::MemoryPermissions;
-use translator;
+use crate::memory::MemoryPermissions;
+use crate::translator;
 
 impl translator::TranslationMemory for Memory {
     fn get_u8(&self, address: u64) -> Option<u8> {

--- a/lib/executor/state.rs
+++ b/lib/executor/state.rs
@@ -1,6 +1,7 @@
-use executor::successor::*;
-/// A concrete state for execution over Falcon IL.
-use executor::*;
+//! A concrete state for execution over Falcon IL.
+
+use crate::executor::successor::*;
+use crate::executor::*;
 use std::collections::BTreeMap;
 
 /// A concrete `State`.

--- a/lib/executor/successor.rs
+++ b/lib/executor/successor.rs
@@ -1,7 +1,7 @@
 //! A successor after concrete evaluation of a Falcon IL Instruction.
 
-use executor::State;
-use il;
+use crate::executor::State;
+use crate::il;
 
 /// A representation of the successor location in an `il::Program` after
 /// execution of an `il::Operation`.

--- a/lib/graph/mod.rs
+++ b/lib/graph/mod.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
-use error::*;
+use crate::error::*;
 
 pub trait Vertex: Clone + Sync {
     // The index of this vertex.

--- a/lib/il/block.rs
+++ b/lib/il/block.rs
@@ -7,7 +7,7 @@
 //!
 //! To create a `Block`, call `ControlFlowGraph::new_block`.
 
-use il::*;
+use crate::il::*;
 use std::fmt;
 
 /// A basic block in Falcon IL.

--- a/lib/il/constant.rs
+++ b/lib/il/constant.rs
@@ -1,6 +1,6 @@
 //! A `Constant` holds a single value.
 
-use il::*;
+use crate::il::*;
 use num_bigint::{BigInt, BigUint, ToBigInt};
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::fmt;

--- a/lib/il/control_flow_graph.rs
+++ b/lib/il/control_flow_graph.rs
@@ -1,6 +1,6 @@
 //! A `ControlFlowGraph` is a directed `Graph` of `Block` and `Edge`.
 
-use il::*;
+use crate::il::*;
 use std::collections::BTreeMap;
 use std::fmt;
 

--- a/lib/il/edge.rs
+++ b/lib/il/edge.rs
@@ -9,7 +9,7 @@
 //! To create a new edge, call `ControlFlowGraph::unconditional_edge` or
 //! `ControlFlowGraph::conditional_edge`.
 
-use il::*;
+use crate::il::*;
 use std::fmt;
 
 /// Edge between IL blocks

--- a/lib/il/expression.rs
+++ b/lib/il/expression.rs
@@ -23,7 +23,7 @@
 
 use std::fmt;
 
-use il::*;
+use crate::il::*;
 
 /// An IL Expression.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]

--- a/lib/il/function.rs
+++ b/lib/il/function.rs
@@ -2,7 +2,7 @@
 //!
 //! We can think of a `Function` as providing _location_ to a `ControlFlowGraph`.
 
-use il::*;
+use crate::il::*;
 
 /// A function for Falcon IL. Provides location and context in a `Program` to a
 /// `ControlFlowGraph`.

--- a/lib/il/instruction.rs
+++ b/lib/il/instruction.rs
@@ -1,6 +1,6 @@
 //! An `Instruction` holds an `Operation`.
 
-use il::*;
+use crate::il::*;
 use std::fmt;
 
 /// An `Instruction` represents location, and non-semantical information about

--- a/lib/il/intrinsic.rs
+++ b/lib/il/intrinsic.rs
@@ -1,6 +1,6 @@
 //! Intrinsics are instructions Falcon cannot model.
 
-use il::*;
+use crate::il::*;
 use std::fmt;
 
 /// An Instrinsic is a lifted instruction Falcon cannot model.

--- a/lib/il/location.rs
+++ b/lib/il/location.rs
@@ -13,7 +13,7 @@
 //! Therefor, we have `ProgramLocation`, which is an Owned type in its own right with no
 //! references.
 
-use il::*;
+use crate::il::*;
 use std::fmt;
 
 /// A location applied to a `Program`.

--- a/lib/il/mod.rs
+++ b/lib/il/mod.rs
@@ -177,8 +177,8 @@
 //! yourself, and can use the accessor methods to gather the information
 //! required.
 
-use error::*;
-use graph;
+use crate::error::*;
+use crate::graph;
 
 mod block;
 mod constant;

--- a/lib/il/operation.rs
+++ b/lib/il/operation.rs
@@ -1,6 +1,6 @@
 //! An `Operation` captures the semantics of the IL.
 
-use il::*;
+use crate::il::*;
 use std::fmt;
 
 /// An IL Operation updates some state.

--- a/lib/il/program.rs
+++ b/lib/il/program.rs
@@ -1,9 +1,9 @@
 //! A `Program` holds multiple `Function`.
 
-use il::*;
+use crate::il::*;
+use crate::RC;
 use std::collections::BTreeMap;
 use std::fmt;
-use RC;
 
 /// A representation of a program by `il::Function`
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/lib/il/scalar.rs
+++ b/lib/il/scalar.rs
@@ -1,6 +1,6 @@
 //! A `Scalar` is a variable which holds a single value.
 
-use il::*;
+use crate::il::*;
 use std::fmt;
 
 /// A `Scalar` is a variable which holds a single value.

--- a/lib/loader/elf/elf.rs
+++ b/lib/loader/elf/elf.rs
@@ -1,8 +1,8 @@
-use architecture::*;
+use crate::architecture::*;
+use crate::loader::*;
+use crate::memory::backing::Memory;
+use crate::memory::MemoryPermissions;
 use goblin;
-use loader::*;
-use memory::backing::Memory;
-use memory::MemoryPermissions;
 use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::Read;
@@ -95,9 +95,9 @@ impl Elf {
             // We need that strtab, and we have to do this one manually.
             // Get the strtab address
             let mut strtab_address = None;
-            for dyn in &dynamic.dyns {
-                if dyn.d_tag == goblin::elf::dynamic::DT_STRTAB {
-                    strtab_address = Some(dyn.d_val);
+            for dyn_ in &dynamic.dyns {
+                if dyn_.d_tag == goblin::elf::dynamic::DT_STRTAB {
+                    strtab_address = Some(dyn_.d_val);
                     break;
                 }
             }
@@ -119,9 +119,9 @@ impl Elf {
                     let size = size as usize;
                     let strtab_bytes = self.bytes.get(start..(start + size)).unwrap();
                     let strtab = goblin::strtab::Strtab::new(&strtab_bytes, 0);
-                    for dyn in dynamic.dyns {
-                        if dyn.d_tag == goblin::elf::dynamic::DT_NEEDED {
-                            let so_name = &strtab[dyn.d_val as usize];
+                    for dyn_ in dynamic.dyns {
+                        if dyn_.d_tag == goblin::elf::dynamic::DT_NEEDED {
+                            let so_name = &strtab[dyn_.d_val as usize];
                             v.push(so_name.to_string());
                         }
                     }

--- a/lib/loader/elf/elf_linker.rs
+++ b/lib/loader/elf/elf_linker.rs
@@ -1,7 +1,7 @@
-use architecture::*;
+use crate::architecture::*;
+use crate::loader::*;
+use crate::memory::backing::Memory;
 use goblin;
-use loader::*;
-use memory::backing::Memory;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::Read;
@@ -378,8 +378,8 @@ impl ElfLinker {
                 dynamic
                     .dyns
                     .iter()
-                    .find(|dyn| dyn.d_tag == tag)
-                    .map(|dyn| dyn.d_val)
+                    .find(|dyn_| dyn_.d_tag == tag)
+                    .map(|dyn_| dyn_.d_val)
             })
         }
 

--- a/lib/loader/json.rs
+++ b/lib/loader/json.rs
@@ -1,10 +1,10 @@
 //! Experimental loader which takes a program specification in Json form.
 
-use architecture::*;
 use base64;
-use loader::*;
-use memory::backing::*;
-use memory::MemoryPermissions;
+use crate::architecture::*;
+use crate::loader::*;
+use crate::memory::backing::*;
+use crate::memory::MemoryPermissions;
 use serde_json;
 use serde_json::Value;
 use std::fs::File;

--- a/lib/loader/mod.rs
+++ b/lib/loader/mod.rs
@@ -18,11 +18,11 @@
 //! # }
 //! ```
 
-use architecture::Architecture;
-use error::*;
-use executor::eval;
-use il;
-use memory;
+use crate::architecture::Architecture;
+use crate::error::*;
+use crate::executor::eval;
+use crate::il;
+use crate::memory;
 use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::fmt;

--- a/lib/loader/pe.rs
+++ b/lib/loader/pe.rs
@@ -1,10 +1,10 @@
 //! ELF Linker/Loader
 
-use architecture::X86;
+use crate::architecture::X86;
+use crate::loader::*;
+use crate::memory::backing::Memory;
+use crate::memory::MemoryPermissions;
 use goblin;
-use loader::*;
-use memory::backing::Memory;
-use memory::MemoryPermissions;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;

--- a/lib/memory/backing.rs
+++ b/lib/memory/backing.rs
@@ -4,14 +4,14 @@
 //! This memory model implements the `TranslationMemory` trait, allowing lifters
 //! to use it to lift instructions.
 
-use architecture::Endian;
-use error::*;
-use executor;
-use il;
-use memory::MemoryPermissions;
+use crate::architecture::Endian;
+use crate::error::*;
+use crate::executor;
+use crate::il;
+use crate::memory::MemoryPermissions;
+use crate::translator::TranslationMemory;
 use std::collections::BTreeMap;
 use std::collections::Bound::Included;
-use translator::TranslationMemory;
 
 /// A section of backed memory. Essentially a vector of type `u8` with
 /// permissions.

--- a/lib/memory/paged.rs
+++ b/lib/memory/paged.rs
@@ -3,15 +3,15 @@
 //!
 //! This memory model operates over types which implement the `Value` trait.
 
-use architecture::Endian;
-use error::*;
-use il;
+use crate::architecture::Endian;
+use crate::error::*;
+use crate::il;
+use crate::RC;
 use std::collections::HashMap;
-use RC;
 
-use memory::backing;
-use memory::value::Value;
-use memory::MemoryPermissions;
+use crate::memory::backing;
+use crate::memory::value::Value;
+use crate::memory::MemoryPermissions;
 
 /// The size of the copy-on-write pages.
 pub const PAGE_SIZE: usize = 1024;
@@ -470,12 +470,12 @@ where
 
 #[cfg(test)]
 mod memory_tests {
-    use architecture::Endian;
-    use il;
-    use memory;
-    use memory::paged::Memory;
-    use memory::MemoryPermissions;
-    use RC;
+    use crate::architecture::Endian;
+    use crate::il;
+    use crate::memory;
+    use crate::memory::paged::Memory;
+    use crate::memory::MemoryPermissions;
+    use crate::RC;
 
     #[test]
     fn big_endian() {

--- a/lib/memory/value.rs
+++ b/lib/memory/value.rs
@@ -1,8 +1,8 @@
 //! A value used in the paged memory model.
 
-use error::*;
-use executor::eval;
-use il;
+use crate::error::*;
+use crate::executor::eval;
+use crate::il;
 use std::fmt::Debug;
 
 /// In order for a value to be used in the paged memory model, it must implement

--- a/lib/translator/mips/mod.rs
+++ b/lib/translator/mips/mod.rs
@@ -1,10 +1,10 @@
 //! Capstone-based translator for MIPS.
 
-use architecture::Endian;
-use error::*;
-use falcon_capstone::capstone;
-use il::*;
-use translator::{BlockTranslationResult, Translator, DEFAULT_TRANSLATION_BLOCK_BYTES};
+use crate::architecture::Endian;
+use crate::error::*;
+use crate::falcon_capstone::capstone;
+use crate::il::*;
+use crate::translator::{BlockTranslationResult, Translator, DEFAULT_TRANSLATION_BLOCK_BYTES};
 
 mod semantics;
 #[cfg(test)]

--- a/lib/translator/mips/semantics.rs
+++ b/lib/translator/mips/semantics.rs
@@ -1,8 +1,8 @@
-use error::*;
-use falcon_capstone::capstone;
-use falcon_capstone::capstone_sys::mips_reg;
-use il::Expression as Expr;
-use il::*;
+use crate::error::*;
+use crate::falcon_capstone::capstone;
+use crate::falcon_capstone::capstone_sys::mips_reg;
+use crate::il::Expression as Expr;
+use crate::il::*;
 
 /// Struct for dealing with x86 registers
 pub struct MIPSRegister {

--- a/lib/translator/mips/test.rs
+++ b/lib/translator/mips/test.rs
@@ -1,10 +1,10 @@
-use architecture;
-use architecture::Endian;
-use executor::*;
-use il::*;
-use memory;
-use translator::mips::*;
-use RC;
+use crate::architecture;
+use crate::architecture::Endian;
+use crate::executor::*;
+use crate::il::*;
+use crate::translator::mips::*;
+use crate::memory;
+use crate::RC;
 
 #[macro_use]
 macro_rules! backing {

--- a/lib/translator/mod.rs
+++ b/lib/translator/mod.rs
@@ -18,9 +18,9 @@
 //! pay attention to the translators. The correct translator will be chosen
 //! automatically.
 
-use error::*;
-use il::*;
-use memory::MemoryPermissions;
+use crate::error::*;
+use crate::il::*;
+use crate::memory::MemoryPermissions;
 use std::collections::{BTreeMap, VecDeque};
 
 pub mod mips;

--- a/lib/translator/ppc/mod.rs
+++ b/lib/translator/ppc/mod.rs
@@ -1,9 +1,9 @@
 //! Capstone-based translator for MIPS.
 
-use error::*;
-use falcon_capstone::capstone;
-use il::*;
-use translator::{BlockTranslationResult, Translator};
+use crate::error::*;
+use crate::falcon_capstone::capstone;
+use crate::il::*;
+use crate::translator::{BlockTranslationResult, Translator};
 
 pub mod semantics;
 #[cfg(test)]

--- a/lib/translator/ppc/semantics.rs
+++ b/lib/translator/ppc/semantics.rs
@@ -1,8 +1,8 @@
-use error::*;
-use falcon_capstone::capstone;
-use falcon_capstone::capstone_sys::ppc_reg;
-use il::Expression as Expr;
-use il::*;
+use crate::error::*;
+use crate::falcon_capstone::capstone;
+use crate::falcon_capstone::capstone_sys::ppc_reg;
+use crate::il::Expression as Expr;
+use crate::il::*;
 
 /// Struct for dealing with x86 registers
 pub struct PPCRegister {

--- a/lib/translator/ppc/test.rs
+++ b/lib/translator/ppc/test.rs
@@ -1,10 +1,10 @@
-use architecture;
-use architecture::Endian;
-use executor::*;
-use il::*;
-use memory;
-use translator::ppc::*;
-use RC;
+use crate::architecture;
+use crate::architecture::Endian;
+use crate::executor::*;
+use crate::il::*;
+use crate::memory;
+use crate::translator::ppc::*;
+use crate::RC;
 
 fn init_driver_block<'d>(
     instruction_bytes: &[u8],

--- a/lib/translator/x86/mod.rs
+++ b/lib/translator/x86/mod.rs
@@ -1,7 +1,7 @@
 //! Capstone-based translator for 32/64-bit x86.
 
-use error::*;
-use translator::{BlockTranslationResult, Translator};
+use crate::error::*;
+use crate::translator::{BlockTranslationResult, Translator};
 
 mod mode;
 mod semantics;

--- a/lib/translator/x86/mode.rs
+++ b/lib/translator/x86/mode.rs
@@ -1,10 +1,10 @@
-use error::*;
+use crate::error::*;
+use crate::falcon_capstone::capstone_sys::{x86_op_type, x86_reg};
+use crate::il::Expression as Expr;
+use crate::il::*;
+use crate::translator::x86::x86register::{get_register, X86Register};
 use falcon_capstone::capstone;
 use falcon_capstone::capstone::cs_x86_op;
-use falcon_capstone::capstone_sys::{x86_op_type, x86_reg};
-use il::Expression as Expr;
-use il::*;
-use translator::x86::x86register::{get_register, X86Register};
 
 /// Mode used by translators to pick the correct registers/operations
 #[derive(Clone, Debug)]

--- a/lib/translator/x86/semantics.rs
+++ b/lib/translator/x86/semantics.rs
@@ -1,11 +1,11 @@
-use error::*;
+use crate::error::*;
+use crate::il::Expression as Expr;
+use crate::il::*;
+use crate::translator::x86::x86register::*;
+use crate::translator::x86::Mode;
 use falcon_capstone::capstone;
 use falcon_capstone::capstone::cs_x86_op;
 use falcon_capstone::capstone_sys::{x86_op_type, x86_reg};
-use il::Expression as Expr;
-use il::*;
-use translator::x86::x86register::*;
-use translator::x86::Mode;
 
 pub(crate) struct Semantics<'s> {
     mode: &'s Mode,

--- a/lib/translator/x86/test.rs
+++ b/lib/translator/x86/test.rs
@@ -1,11 +1,11 @@
-use architecture;
-use architecture::Endian;
-use executor::*;
-use il;
-use memory;
-use translator::x86::Amd64;
-use translator::Translator;
-use RC;
+use crate::architecture;
+use crate::architecture::Endian;
+use crate::executor::*;
+use crate::il;
+use crate::memory;
+use crate::translator::x86::Amd64;
+use crate::translator::Translator;
+use crate::RC;
 
 fn init_amd64_driver<'d>(
     instruction_bytes: Vec<u8>,

--- a/lib/translator/x86/translator.rs
+++ b/lib/translator/x86/translator.rs
@@ -1,12 +1,12 @@
 //! Capstone-based translator for 32-bit x86.
 
-use error::*;
+use crate::error::*;
+use crate::il::*;
+use crate::translator::x86::mode::Mode;
+use crate::translator::BlockTranslationResult;
 use falcon_capstone::{capstone, capstone_sys};
-use il::*;
-use translator::x86::mode::Mode;
-use translator::BlockTranslationResult;
 
-use translator::x86::semantics::Semantics;
+use crate::translator::x86::semantics::Semantics;
 
 fn unhandled_intrinsic(
     control_flow_graph: &mut ControlFlowGraph,

--- a/lib/translator/x86/x86register.rs
+++ b/lib/translator/x86/x86register.rs
@@ -1,8 +1,8 @@
-use error::*;
+use crate::error::*;
+use crate::il::Expression as Expr;
+use crate::il::*;
+use crate::translator::x86::mode::Mode;
 use falcon_capstone::capstone_sys::x86_reg;
-use il::Expression as Expr;
-use il::*;
-use translator::x86::mode::Mode;
 
 const X86REGISTERS: &'static [X86Register] = &[
     X86Register {


### PR DESCRIPTION
Most of the changes were changing `use` statements and some variables
conflicting with keywords.