### PR TITLE
Lift x86 endbr32/64 and ud0 instructions to Intrinsic

### DIFF
--- a/lib/translator/x86/translator.rs
+++ b/lib/translator/x86/translator.rs
@@ -431,6 +431,10 @@ pub(crate) fn translate_block(
                 | capstone::x86_insn::X86_INS_LFENCE => {
                     unhandled_intrinsic(&mut instruction_graph, &instruction)
                 }
+                #[cfg(feature = "capstone4")]
+                capstone::x86_insn::X86_INS_UD0 => {
+                    unhandled_intrinsic(&mut instruction_graph, &instruction)
+                }
 
                 _ => {
                     return Err(format!(

--- a/lib/translator/x86/translator.rs
+++ b/lib/translator/x86/translator.rs
@@ -435,6 +435,11 @@ pub(crate) fn translate_block(
                 capstone::x86_insn::X86_INS_UD0 => {
                     unhandled_intrinsic(&mut instruction_graph, &instruction)
                 }
+                #[cfg(feature = "capstone4")]
+                capstone::x86_insn::X86_INS_ENDBR32
+                | capstone::x86_insn::X86_INS_ENDBR64 => {
+                    unhandled_intrinsic(&mut instruction_graph, &instruction)
+                }
 
                 _ => {
                     return Err(format!(


### PR DESCRIPTION
Handling endbr32/64 instructions fixes some lifting errors when loading binaries compiled with CET enabled.