### PR TITLE
Lift x86 fences to Intrinsic

### DIFF
--- a/lib/translator/x86/translator.rs
+++ b/lib/translator/x86/translator.rs
@@ -426,6 +426,11 @@ pub(crate) fn translate_block(
                     unhandled_intrinsic(&mut instruction_graph, &instruction)
                 }
                 capstone::x86_insn::X86_INS_XOR => semantics.xor(&mut instruction_graph),
+                capstone::x86_insn::X86_INS_MFENCE
+                | capstone::x86_insn::X86_INS_SFENCE
+                | capstone::x86_insn::X86_INS_LFENCE => {
+                    unhandled_intrinsic(&mut instruction_graph, &instruction)
+                }
 
                 _ => {
                     return Err(format!(


### PR DESCRIPTION
As proposed in https://github.com/falconre/falcon/pull/54#issuecomment-576538554 fences are lifted to `Intrinsic` instructions to keep the IL simple. If fences are required during analysis, then something like https://github.com/falconre/finch/blob/f880cf79add2e096c9644aa5f1eb7bddf2e590ec/lib/platform/linux/mips.rs#L187 can be used to obtain them.