### PR TITLE
Expression: Drop dedup from scalars and scalars_mut

### DIFF
--- a/lib/il/expression.rs
+++ b/lib/il/expression.rs
@@ -267,8 +267,6 @@ impl Expression {
                 scalars.append(&mut else_.scalars());
             }
         }
-        scalars.sort();
-        scalars.dedup();
         scalars
     }
 
@@ -308,8 +306,6 @@ impl Expression {
                 scalars.append(&mut else_.scalars_mut());
             }
         }
-        scalars.sort();
-        scalars.dedup();
         scalars
     }
 


### PR DESCRIPTION
As the function documentation states, **all** scalars used in the expression will be returned. Therefore, the dedup is not correct as the caller expects all scalar instances. This is especially true when mutating the scalars, as otherwise some scalars which appear multiple times with same name will be missed.

E.g. `x + y * x` should give [x, y, x] instead of [x, y] -> misses second x instance with dedup!

If the caller only requires the names of the scalars appearing in the expression, then the caller could simply call dedup.

My use-case for mutating **all** scalars of an expression is the SSA transformation of IL expressions:
```
impl SSARename for il::Expression {
    fn rename_scalars(&mut self, renamer: &mut ScalarRenamer) -> Result<()> {
        for scalar in self.scalars_mut() {
            let ssa_name = renamer.get_ssa_name(scalar)?;
            scalar.set_name(ssa_name);
        }

        Ok(())
    }
}
```