### PR TITLE
Graph: Replace edges_in/out by a set of predecessors/successors

### DIFF
--- a/lib/il/control_flow_graph.rs
+++ b/lib/il/control_flow_graph.rs
@@ -116,12 +116,12 @@ impl ControlFlowGraph {
     }
 
     /// Get every incoming edge to a block
-    pub fn edges_in(&self, index: usize) -> Result<&Vec<Edge>> {
+    pub fn edges_in(&self, index: usize) -> Result<Vec<&Edge>> {
         self.graph.edges_in(index)
     }
 
     /// Get every outgoing edge from a block
-    pub fn edges_out(&self, index: usize) -> Result<&Vec<Edge>> {
+    pub fn edges_out(&self, index: usize) -> Result<Vec<&Edge>> {
         self.graph.edges_out(index)
     }
 


### PR DESCRIPTION
The old approach had the big problem that Edges were duplicated multiple times. Therefore, changing an edge by e.g. `Graph::edge_mut` can result in out of sync information between `edges`, `edges_in` and `edges_out`.

The new approach still allows fast lookup of edge targets (successors/predecessors), but avoids the duplication by storing vertex indices instead. 

Another fix for this problem would be to use ref-counted edges instead.