### PR TITLE
Use the Instruction Address as Temporary Scalar Index

### DIFF
--- a/lib/il/block.rs
+++ b/lib/il/block.rs
@@ -17,8 +17,6 @@ pub struct Block {
     index: usize,
     /// an internal counter for the next block-unique instruction.
     next_instruction_index: usize,
-    /// An internal counter for the next block-unique temporary variable.
-    next_temp_index: usize,
     /// The instructions for this block.
     instructions: Vec<Instruction>,
     /// The phi nodes for this block.
@@ -30,7 +28,6 @@ impl Block {
         Block {
             index: index,
             next_instruction_index: 0,
-            next_temp_index: 0,
             instructions: Vec::new(),
             phi_nodes: Vec::new(),
         }
@@ -141,13 +138,6 @@ impl Block {
         let mut clone = self.clone();
         clone.index = index;
         clone
-    }
-
-    /// Generates a temporary scalar unique to this block.
-    pub fn temp(&mut self, bits: usize) -> Scalar {
-        let next_index = self.next_temp_index;
-        self.next_temp_index = next_index + 1;
-        Scalar::new(format!("temp_{}.{}", self.index, next_index), bits)
     }
 
     /// Adds an assign operation to the end of this block.

--- a/lib/il/scalar.rs
+++ b/lib/il/scalar.rs
@@ -25,6 +25,11 @@ impl Scalar {
         }
     }
 
+    /// Create a temporary `Scalar` with the given index and bitness.
+    pub fn temp(index: u64, bits: usize) -> Self {
+        Self::new(format!("temp_0x{:X}", index), bits)
+    }
+
     /// Gets the bitness of the `Scalar`.
     pub fn bits(&self) -> usize {
         self.bits

--- a/lib/translator/mips/semantics.rs
+++ b/lib/translator/mips/semantics.rs
@@ -1114,7 +1114,7 @@ pub fn madd(
         let block = control_flow_graph.new_block()?;
 
         let tmp0 = Scalar::temp(instruction.address, 64);
-        let tmp1 = Scalar::temp(instruction.address, 64);
+        let tmp1 = Scalar::temp(instruction.address + 1, 64);
         block.assign(
             tmp0.clone(),
             Expr::mul(Expr::sext(64, rs)?, Expr::sext(64, rt)?)?,
@@ -1160,7 +1160,7 @@ pub fn maddu(
         let block = control_flow_graph.new_block()?;
 
         let tmp0 = Scalar::temp(instruction.address, 64);
-        let tmp1 = Scalar::temp(instruction.address, 64);
+        let tmp1 = Scalar::temp(instruction.address + 1, 64);
         block.assign(
             tmp0.clone(),
             Expr::mul(Expr::zext(64, rs)?, Expr::zext(64, rt)?)?,
@@ -1374,7 +1374,7 @@ pub fn msub(
         let block = control_flow_graph.new_block()?;
 
         let tmp0 = Scalar::temp(instruction.address, 64);
-        let tmp1 = Scalar::temp(instruction.address, 64);
+        let tmp1 = Scalar::temp(instruction.address + 1, 64);
         block.assign(
             tmp0.clone(),
             Expr::mul(Expr::sext(64, rs)?, Expr::sext(64, rt)?)?,
@@ -1420,7 +1420,7 @@ pub fn msubu(
         let block = control_flow_graph.new_block()?;
 
         let tmp0 = Scalar::temp(instruction.address, 64);
-        let tmp1 = Scalar::temp(instruction.address, 64);
+        let tmp1 = Scalar::temp(instruction.address + 1, 64);
         block.assign(
             tmp0.clone(),
             Expr::mul(Expr::zext(64, rs)?, Expr::zext(64, rt)?)?,

--- a/lib/translator/mips/semantics.rs
+++ b/lib/translator/mips/semantics.rs
@@ -853,7 +853,7 @@ pub fn lb(control_flow_graph: &mut ControlFlowGraph, instruction: &capstone::Ins
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        let temp = block.temp(8);
+        let temp = Scalar::temp(instruction.address, 8);
         block.load(temp.clone(), Expr::add(base, offset)?);
         block.assign(dst, Expr::sext(32, temp.into())?);
 
@@ -877,7 +877,7 @@ pub fn lbu(control_flow_graph: &mut ControlFlowGraph, instruction: &capstone::In
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        let temp = block.temp(8);
+        let temp = Scalar::temp(instruction.address, 8);
         block.load(temp.clone(), Expr::add(base, offset)?);
         block.assign(dst, Expr::zext(32, temp.into())?);
 
@@ -901,7 +901,7 @@ pub fn lh(control_flow_graph: &mut ControlFlowGraph, instruction: &capstone::Ins
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        let temp = block.temp(16);
+        let temp = Scalar::temp(instruction.address, 16);
         block.load(temp.clone(), Expr::add(base, offset)?);
         block.assign(dst, Expr::sext(32, temp.into())?);
 
@@ -925,7 +925,7 @@ pub fn lhu(control_flow_graph: &mut ControlFlowGraph, instruction: &capstone::In
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        let temp = block.temp(16);
+        let temp = Scalar::temp(instruction.address, 16);
         block.load(temp.clone(), Expr::add(base, offset)?);
         block.assign(dst, Expr::zext(32, temp.into())?);
 
@@ -1028,7 +1028,7 @@ pub fn lwl(control_flow_graph: &mut ControlFlowGraph, instruction: &capstone::In
         let bytes_to_shift = Expr::and(expr_const(3, 32), address.clone())?;
         let bits_to_shift = Expr::shl(bytes_to_shift, expr_const(3, 32))?;
 
-        let tmp = block.temp(32);
+        let tmp = Scalar::temp(instruction.address, 32);
         block.load(tmp.clone(), address);
 
         // clear the dst register by shifting left then right
@@ -1075,7 +1075,7 @@ pub fn lwr(control_flow_graph: &mut ControlFlowGraph, instruction: &capstone::In
         let mask = Expr::sub(mask_bit, expr_const(1, 32))?;
 
         // load our word from memory
-        let tmp = block.temp(32);
+        let tmp = Scalar::temp(instruction.address, 32);
         block.load(tmp.clone(), address);
 
         // we want to and this word with our mask to remove the high bits
@@ -1113,8 +1113,8 @@ pub fn madd(
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        let tmp0 = block.temp(64);
-        let tmp1 = block.temp(64);
+        let tmp0 = Scalar::temp(instruction.address, 64);
+        let tmp1 = Scalar::temp(instruction.address, 64);
         block.assign(
             tmp0.clone(),
             Expr::mul(Expr::sext(64, rs)?, Expr::sext(64, rt)?)?,
@@ -1159,8 +1159,8 @@ pub fn maddu(
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        let tmp0 = block.temp(64);
-        let tmp1 = block.temp(64);
+        let tmp0 = Scalar::temp(instruction.address, 64);
+        let tmp1 = Scalar::temp(instruction.address, 64);
         block.assign(
             tmp0.clone(),
             Expr::mul(Expr::zext(64, rs)?, Expr::zext(64, rt)?)?,
@@ -1373,8 +1373,8 @@ pub fn msub(
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        let tmp0 = block.temp(64);
-        let tmp1 = block.temp(64);
+        let tmp0 = Scalar::temp(instruction.address, 64);
+        let tmp1 = Scalar::temp(instruction.address, 64);
         block.assign(
             tmp0.clone(),
             Expr::mul(Expr::sext(64, rs)?, Expr::sext(64, rt)?)?,
@@ -1419,8 +1419,8 @@ pub fn msubu(
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        let tmp0 = block.temp(64);
-        let tmp1 = block.temp(64);
+        let tmp0 = Scalar::temp(instruction.address, 64);
+        let tmp1 = Scalar::temp(instruction.address, 64);
         block.assign(
             tmp0.clone(),
             Expr::mul(Expr::zext(64, rs)?, Expr::zext(64, rt)?)?,
@@ -1536,7 +1536,7 @@ pub fn mult(
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        let tmp = block.temp(64);
+        let tmp = Scalar::temp(instruction.address, 64);
         block.assign(
             tmp.clone(),
             Expr::mul(Expr::sext(64, rs)?, Expr::sext(64, rt)?)?,
@@ -1569,7 +1569,7 @@ pub fn multu(
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        let tmp = block.temp(64);
+        let tmp = Scalar::temp(instruction.address, 64);
         block.assign(
             tmp.clone(),
             Expr::mul(Expr::zext(64, rs)?, Expr::zext(64, rt)?)?,
@@ -2080,7 +2080,7 @@ pub fn sra(control_flow_graph: &mut ControlFlowGraph, instruction: &capstone::In
         let block = control_flow_graph.new_block()?;
 
         // set up the mask to put the arithmetic in shift arithmetic right
-        let temp = block.temp(32);
+        let temp = Scalar::temp(instruction.address, 32);
         let expr = Expr::shl(
             Expr::sub(
                 expr_const(0, 32),
@@ -2115,7 +2115,7 @@ pub fn srav(
         let block = control_flow_graph.new_block()?;
 
         // set up the mask to put the arithmetic in shift arithmetic right
-        let temp = block.temp(32);
+        let temp = Scalar::temp(instruction.address, 32);
         let expr = Expr::shl(
             Expr::sub(
                 expr_const(0, 32),
@@ -2358,7 +2358,7 @@ pub fn swl(control_flow_graph: &mut ControlFlowGraph, instruction: &capstone::In
         let address = Expr::add(base, offset)?;
 
         // load the value currently in memory
-        let tmp = block.temp(32);
+        let tmp = Scalar::temp(instruction.address, 32);
         block.load(
             tmp.clone(),
             Expr::and(expr_const(0xffff_fffc, 32), address.clone())?,
@@ -2424,7 +2424,7 @@ pub fn swr(control_flow_graph: &mut ControlFlowGraph, instruction: &capstone::In
         let mask = Expr::sub(mask_bit, expr_const(1, 32))?;
 
         // load our word from memory
-        let tmp = block.temp(32);
+        let tmp = Scalar::temp(instruction.address, 32);
         block.load(tmp.clone(), address.clone());
 
         // zero out the words we're about to set in dst

--- a/lib/translator/ppc/semantics.rs
+++ b/lib/translator/ppc/semantics.rs
@@ -810,7 +810,7 @@ pub fn lbz(control_flow_graph: &mut ControlFlowGraph, instruction: &capstone::In
 
         let ea = Expr::add(offset, base)?;
 
-        let temp = block.temp(8);
+        let temp = Scalar::temp(instruction.address, 8);
         block.load(temp.clone(), ea);
         block.assign(dst.clone(), Expression::zext(dst.bits(), temp.into())?);
 

--- a/lib/translator/x86/mode.rs
+++ b/lib/translator/x86/mode.rs
@@ -145,7 +145,7 @@ impl Mode {
         let op = self.operand_value(operand, instruction)?;
 
         if operand.type_ == x86_op_type::X86_OP_MEM {
-            let temp = block.temp(operand.size as usize * 8);
+            let temp = Scalar::temp(instruction.address, operand.size as usize * 8);
             block.load(temp.clone(), op);
             return Ok(temp.into());
         }
@@ -178,8 +178,13 @@ impl Mode {
     }
 
     /// Convenience function to pop a value off the stack
-    pub fn pop_value(&self, block: &mut Block, bits: usize) -> Result<Expression> {
-        let temp = block.temp(bits);
+    pub fn pop_value(
+        &self,
+        block: &mut Block,
+        bits: usize,
+        instruction: &capstone::Instr,
+    ) -> Result<Expression> {
+        let temp = Scalar::temp(instruction.address, bits);
 
         block.load(temp.clone(), self.sp().into());
         block.assign(

--- a/lib/translator/x86/semantics.rs
+++ b/lib/translator/x86/semantics.rs
@@ -38,6 +38,11 @@ impl<'s> Semantics<'s> {
         }
     }
 
+    /// Generates a temporary scalar unique to this instruction.
+    pub fn temp(&self, bits: usize) -> Scalar {
+        Scalar::temp(self.instruction.address, bits)
+    }
+
     pub fn operand_load(&self, mut block: &mut Block, operand: &cs_x86_op) -> Result<Expression> {
         self.mode
             .operand_load(&mut block, operand, self.instruction())
@@ -421,7 +426,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = block.temp(lhs.bits());
+            let result = self.temp(lhs.bits());
 
             // perform addition
             let addition = Expr::add(lhs.clone(), rhs.clone())?;
@@ -459,7 +464,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = block.temp(lhs.bits());
+            let result = self.temp(lhs.bits());
 
             // perform addition
             block.assign(result.clone(), Expr::add(lhs.clone(), rhs.clone())?);
@@ -499,7 +504,7 @@ impl<'s> Semantics<'s> {
                 rhs = Expr::sext(lhs.bits(), rhs)?;
             }
 
-            let result = block.temp(lhs.bits());
+            let result = self.temp(lhs.bits());
 
             // perform addition
             block.assign(result.clone(), Expr::and(lhs.clone(), rhs.clone())?);
@@ -763,7 +768,7 @@ impl<'s> Semantics<'s> {
 
             // let's ensure we have equal sorts
             if offset.bits() != base.bits() {
-                let temp = block.temp(base.bits());
+                let temp = self.temp(base.bits());
                 block.assign(
                     temp.clone(),
                     Expr::zext(base.bits(), offset.clone().into())?,
@@ -771,7 +776,7 @@ impl<'s> Semantics<'s> {
                 offset = temp.into();
             }
 
-            let temp = block.temp(base.bits());
+            let temp = self.temp(base.bits());
             block.assign(temp.clone(), Expr::shr(base.into(), offset.into())?);
             block.assign(scalar("CF", 1), Expr::trun(1, temp.into())?);
 
@@ -810,7 +815,7 @@ impl<'s> Semantics<'s> {
 
             // let's ensure we have equal sorts
             if offset.bits() != base.bits() {
-                let temp = block.temp(base.bits());
+                let temp = self.temp(base.bits());
                 block.assign(
                     temp.clone(),
                     Expr::zext(base.bits(), offset.clone().into())?,
@@ -819,7 +824,7 @@ impl<'s> Semantics<'s> {
             }
 
             // this handles the assign to CF
-            let temp = block.temp(base.bits());
+            let temp = self.temp(base.bits());
             block.assign(temp.clone(), Expr::shr(base.into(), offset.clone().into())?);
             block.assign(scalar("CF", 1), Expr::trun(1, temp.clone().into())?);
 
@@ -862,7 +867,7 @@ impl<'s> Semantics<'s> {
 
             // let's ensure we have equal sorts
             if offset.bits() != base.bits() {
-                let temp = block.temp(base.bits());
+                let temp = self.temp(base.bits());
                 block.assign(
                     temp.clone(),
                     Expr::zext(base.bits(), offset.clone().into())?,
@@ -871,7 +876,7 @@ impl<'s> Semantics<'s> {
             }
 
             // this handles the assign to CF
-            let temp = block.temp(base.bits());
+            let temp = self.temp(base.bits());
             block.assign(
                 temp.clone(),
                 Expr::shr(base.clone().into(), offset.clone().into())?,
@@ -919,7 +924,7 @@ impl<'s> Semantics<'s> {
 
             // let's ensure we have equal sorts
             if offset.bits() != base.bits() {
-                let temp = block.temp(base.bits());
+                let temp = self.temp(base.bits());
                 block.assign(
                     temp.clone(),
                     Expr::zext(base.bits(), offset.clone().into())?,
@@ -928,7 +933,7 @@ impl<'s> Semantics<'s> {
             }
 
             // this handles the assign to CF
-            let temp = block.temp(base.bits());
+            let temp = self.temp(base.bits());
             block.assign(
                 temp.clone(),
                 Expr::shr(base.clone().into(), offset.clone().into())?,
@@ -1513,8 +1518,8 @@ impl<'s> Semantics<'s> {
                 _ => return Err("invalid bit-width in x86 div".into()),
             };
 
-            let quotient = block.temp(divisor.bits());
-            let remainder = block.temp(divisor.bits());
+            let quotient = self.temp(divisor.bits());
+            let remainder = self.temp(divisor.bits());
 
             block.assign(
                 quotient.clone(),
@@ -1600,8 +1605,8 @@ impl<'s> Semantics<'s> {
                 _ => return Err("invalid bit-width in x86 div".into()),
             };
 
-            let quotient = block.temp(divisor.bits());
-            let remainder = block.temp(divisor.bits());
+            let quotient = self.temp(divisor.bits());
+            let remainder = self.temp(divisor.bits());
 
             block.assign(
                 quotient.clone(),
@@ -1698,7 +1703,7 @@ impl<'s> Semantics<'s> {
             // Perform multiplication
             let bit_width = multiplicand.bits() * 2;
 
-            let result = block.temp(bit_width);
+            let result = self.temp(bit_width);
             block.assign(
                 result.clone(),
                 Expr::mul(
@@ -1887,7 +1892,9 @@ impl<'s> Semantics<'s> {
             let bp = self.get_register(x86_reg::X86_REG_EBP)?.get_full()?;
 
             sp.set(&mut block, bp.get()?)?;
-            let temp = self.mode().pop_value(&mut block, self.mode().bits())?;
+            let temp = self
+                .mode()
+                .pop_value(&mut block, self.mode().bits(), self.instruction)?;
             bp.set(&mut block, temp)?;
 
             block.index()
@@ -2184,7 +2191,7 @@ impl<'s> Semantics<'s> {
         let head_index = {
             let block = control_flow_graph.new_block()?;
 
-            let temp = block.temp(bits_size);
+            let temp = self.temp(bits_size);
             block.load(temp.clone(), si.get()?);
             block.store(di.get()?, temp.into());
 
@@ -2315,7 +2322,7 @@ impl<'s> Semantics<'s> {
             };
 
             let bit_width = rhs.bits() * 2;
-            let result = block.temp(bit_width);
+            let result = self.temp(bit_width);
             let expr = Expr::mul(
                 Expr::zext(bit_width, lhs)?,
                 Expr::zext(bit_width, rhs.clone())?,
@@ -2386,7 +2393,7 @@ impl<'s> Semantics<'s> {
 
             let dst = self.operand_load(&mut block, &detail.operands[0])?;
 
-            let result = block.temp(dst.bits());
+            let result = self.temp(dst.bits());
 
             block.assign(
                 scalar("CF", 1),
@@ -2464,7 +2471,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let mut rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = block.temp(lhs.bits());
+            let result = self.temp(lhs.bits());
 
             if lhs.bits() != rhs.bits() {
                 rhs = Expr::sext(lhs.bits(), rhs)?;
@@ -2535,7 +2542,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let temp = block.temp(lhs.bits());
+            let temp = self.temp(lhs.bits());
 
             block.assign(
                 temp.clone(),
@@ -2588,7 +2595,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let temp = block.temp(lhs.bits());
+            let temp = self.temp(lhs.bits());
 
             block.assign(
                 temp.clone(),
@@ -2641,7 +2648,7 @@ impl<'s> Semantics<'s> {
             let dst = self.get_register(detail.operands[0].reg())?;
             let src = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let temp = block.temp(dst.bits());
+            let temp = self.temp(dst.bits());
 
             block.assign(
                 temp.clone(),
@@ -2696,7 +2703,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let temp = block.temp(lhs.bits());
+            let temp = self.temp(lhs.bits());
 
             block.assign(
                 temp.clone(),
@@ -2814,7 +2821,7 @@ impl<'s> Semantics<'s> {
                 expr_const(0xffffffff, src.bits()),
             )?;
 
-            let temp = block.temp(detail.operands[0].size as usize * 8);
+            let temp = self.temp(detail.operands[0].size as usize * 8);
 
             block.assign(temp.clone(), result0);
             block.assign(
@@ -2925,12 +2932,12 @@ impl<'s> Semantics<'s> {
                     8,
                     Expression::shr(rhs.clone(), expr_const(i as u64 * 8, lhs.bits()))?,
                 )?;
-                let temp = block.temp(8);
+                let temp = self.temp(8);
                 block.assign(temp.clone(), Expression::sub(ll, rr)?);
                 temp_vars.push(temp);
             }
 
-            let result = block.temp(lhs.bits());
+            let result = self.temp(lhs.bits());
             block.assign(result.clone(), expr_const(0, lhs.bits()));
             for i in 0..temp_vars.len() {
                 block.assign(
@@ -2998,12 +3005,15 @@ impl<'s> Semantics<'s> {
             let mut block = control_flow_graph.new_block()?;
 
             let value = match detail.operands[0].type_ {
-                x86_op_type::X86_OP_MEM => self
-                    .mode()
-                    .pop_value(&mut block, detail.operands[0].size as usize * 8)?,
+                x86_op_type::X86_OP_MEM => self.mode().pop_value(
+                    &mut block,
+                    detail.operands[0].size as usize * 8,
+                    self.instruction,
+                )?,
                 x86_op_type::X86_OP_REG => self.mode().pop_value(
                     &mut block,
                     self.get_register(detail.operands[0].reg())?.bits(),
+                    self.instruction,
                 )?,
                 _ => bail!("invalid op type for `pop` instruction"),
             };
@@ -3047,7 +3057,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = block.temp(lhs.bits());
+            let result = self.temp(lhs.bits());
             block.assign(result.clone(), expr_const(0, result.bits()));
             for i in 0..lhs.bits() / 16 {
                 let ll = Expression::and(
@@ -3094,7 +3104,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = block.temp(lhs.bits());
+            let result = self.temp(lhs.bits());
             block.assign(result.clone(), expr_const(0, result.bits()));
             for i in 0..lhs.bits() / 32 {
                 let ll = Expression::and(
@@ -3159,7 +3169,9 @@ impl<'s> Semantics<'s> {
         let block_index = {
             let mut block = control_flow_graph.new_block()?;
 
-            let value = self.mode().pop_value(&mut block, self.mode().bits())?;
+            let value = self
+                .mode()
+                .pop_value(&mut block, self.mode().bits(), self.instruction)?;
 
             if detail.op_count == 1 {
                 let imm = self.operand_load(&mut block, &detail.operands[0])?;
@@ -3386,7 +3398,7 @@ impl<'s> Semantics<'s> {
 
             // Do the SAR
             let expr = Expr::or(expr, Expr::shr(lhs.clone(), rhs.clone())?)?;
-            let temp = block.temp(lhs.bits());
+            let temp = self.temp(lhs.bits());
             block.assign(temp.clone(), expr);
 
             // OF is the last bit shifted out
@@ -3450,7 +3462,7 @@ impl<'s> Semantics<'s> {
             let mut block = control_flow_graph.new_block()?;
 
             // get operands
-            let temp = block.temp(8);
+            let temp = self.temp(8);
             block.load(temp.clone(), di.get()?);
             let expr = Expr::sub(al.get()?, temp.clone().into())?;
 
@@ -3516,7 +3528,7 @@ impl<'s> Semantics<'s> {
             let mut block = control_flow_graph.new_block()?;
 
             // get operands
-            let temp = block.temp(16);
+            let temp = self.temp(16);
             block.load(temp.clone(), di.get()?);
             let expr = Expr::sub(ax.get()?, temp.clone().into())?;
 
@@ -3930,7 +3942,7 @@ impl<'s> Semantics<'s> {
                 rhs = Expr::sext(lhs.bits(), rhs)?;
             }
 
-            let result = block.temp(lhs.bits());
+            let result = self.temp(lhs.bits());
             block.assign(result.clone(), Expr::sub(lhs.clone(), rhs.clone())?);
 
             // calculate flags
@@ -4056,7 +4068,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = block.temp(lhs.bits());
+            let result = self.temp(lhs.bits());
 
             // perform addition
             block.assign(result.clone(), Expr::add(lhs.clone(), rhs.clone())?);
@@ -4090,7 +4102,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let tmp = block.temp(lhs.bits());
+            let tmp = self.temp(lhs.bits());
             block.assign(tmp.clone(), lhs.clone());
 
             self.operand_store(&mut block, &detail.operands[0], rhs)?;
@@ -4120,7 +4132,7 @@ impl<'s> Semantics<'s> {
                 rhs = Expr::sext(lhs.bits(), rhs)?;
             }
 
-            let result = block.temp(lhs.bits());
+            let result = self.temp(lhs.bits());
 
             // In the event lhs and rhs are the same, this is actually an
             // assignment of zero. Treat it as such.

--- a/lib/translator/x86/semantics.rs
+++ b/lib/translator/x86/semantics.rs
@@ -39,8 +39,8 @@ impl<'s> Semantics<'s> {
     }
 
     /// Generates a temporary scalar unique to this instruction.
-    pub fn temp(&self, bits: usize) -> Scalar {
-        Scalar::temp(self.instruction.address, bits)
+    pub fn temp(&self, subindex: usize, bits: usize) -> Scalar {
+        Scalar::new(format!("temp_0x{:X}_{}", self.instruction.address, subindex), bits)
     }
 
     pub fn operand_load(&self, mut block: &mut Block, operand: &cs_x86_op) -> Result<Expression> {
@@ -426,7 +426,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = self.temp(lhs.bits());
+            let result = self.temp(0, lhs.bits());
 
             // perform addition
             let addition = Expr::add(lhs.clone(), rhs.clone())?;
@@ -464,7 +464,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = self.temp(lhs.bits());
+            let result = self.temp(0, lhs.bits());
 
             // perform addition
             block.assign(result.clone(), Expr::add(lhs.clone(), rhs.clone())?);
@@ -504,7 +504,7 @@ impl<'s> Semantics<'s> {
                 rhs = Expr::sext(lhs.bits(), rhs)?;
             }
 
-            let result = self.temp(lhs.bits());
+            let result = self.temp(0, lhs.bits());
 
             // perform addition
             block.assign(result.clone(), Expr::and(lhs.clone(), rhs.clone())?);
@@ -768,7 +768,7 @@ impl<'s> Semantics<'s> {
 
             // let's ensure we have equal sorts
             if offset.bits() != base.bits() {
-                let temp = self.temp(base.bits());
+                let temp = self.temp(0, base.bits());
                 block.assign(
                     temp.clone(),
                     Expr::zext(base.bits(), offset.clone().into())?,
@@ -776,7 +776,7 @@ impl<'s> Semantics<'s> {
                 offset = temp.into();
             }
 
-            let temp = self.temp(base.bits());
+            let temp = self.temp(0, base.bits());
             block.assign(temp.clone(), Expr::shr(base.into(), offset.into())?);
             block.assign(scalar("CF", 1), Expr::trun(1, temp.into())?);
 
@@ -815,7 +815,7 @@ impl<'s> Semantics<'s> {
 
             // let's ensure we have equal sorts
             if offset.bits() != base.bits() {
-                let temp = self.temp(base.bits());
+                let temp = self.temp(0, base.bits());
                 block.assign(
                     temp.clone(),
                     Expr::zext(base.bits(), offset.clone().into())?,
@@ -824,7 +824,7 @@ impl<'s> Semantics<'s> {
             }
 
             // this handles the assign to CF
-            let temp = self.temp(base.bits());
+            let temp = self.temp(1, base.bits());
             block.assign(temp.clone(), Expr::shr(base.into(), offset.clone().into())?);
             block.assign(scalar("CF", 1), Expr::trun(1, temp.clone().into())?);
 
@@ -867,7 +867,7 @@ impl<'s> Semantics<'s> {
 
             // let's ensure we have equal sorts
             if offset.bits() != base.bits() {
-                let temp = self.temp(base.bits());
+                let temp = self.temp(0, base.bits());
                 block.assign(
                     temp.clone(),
                     Expr::zext(base.bits(), offset.clone().into())?,
@@ -876,7 +876,7 @@ impl<'s> Semantics<'s> {
             }
 
             // this handles the assign to CF
-            let temp = self.temp(base.bits());
+            let temp = self.temp(1, base.bits());
             block.assign(
                 temp.clone(),
                 Expr::shr(base.clone().into(), offset.clone().into())?,
@@ -924,7 +924,7 @@ impl<'s> Semantics<'s> {
 
             // let's ensure we have equal sorts
             if offset.bits() != base.bits() {
-                let temp = self.temp(base.bits());
+                let temp = self.temp(0, base.bits());
                 block.assign(
                     temp.clone(),
                     Expr::zext(base.bits(), offset.clone().into())?,
@@ -933,7 +933,7 @@ impl<'s> Semantics<'s> {
             }
 
             // this handles the assign to CF
-            let temp = self.temp(base.bits());
+            let temp = self.temp(1, base.bits());
             block.assign(
                 temp.clone(),
                 Expr::shr(base.clone().into(), offset.clone().into())?,
@@ -1518,8 +1518,8 @@ impl<'s> Semantics<'s> {
                 _ => return Err("invalid bit-width in x86 div".into()),
             };
 
-            let quotient = self.temp(divisor.bits());
-            let remainder = self.temp(divisor.bits());
+            let quotient = self.temp(0, divisor.bits());
+            let remainder = self.temp(1, divisor.bits());
 
             block.assign(
                 quotient.clone(),
@@ -1605,8 +1605,8 @@ impl<'s> Semantics<'s> {
                 _ => return Err("invalid bit-width in x86 div".into()),
             };
 
-            let quotient = self.temp(divisor.bits());
-            let remainder = self.temp(divisor.bits());
+            let quotient = self.temp(0, divisor.bits());
+            let remainder = self.temp(1, divisor.bits());
 
             block.assign(
                 quotient.clone(),
@@ -1703,7 +1703,7 @@ impl<'s> Semantics<'s> {
             // Perform multiplication
             let bit_width = multiplicand.bits() * 2;
 
-            let result = self.temp(bit_width);
+            let result = self.temp(0, bit_width);
             block.assign(
                 result.clone(),
                 Expr::mul(
@@ -2191,7 +2191,7 @@ impl<'s> Semantics<'s> {
         let head_index = {
             let block = control_flow_graph.new_block()?;
 
-            let temp = self.temp(bits_size);
+            let temp = self.temp(0, bits_size);
             block.load(temp.clone(), si.get()?);
             block.store(di.get()?, temp.into());
 
@@ -2322,7 +2322,7 @@ impl<'s> Semantics<'s> {
             };
 
             let bit_width = rhs.bits() * 2;
-            let result = self.temp(bit_width);
+            let result = self.temp(0, bit_width);
             let expr = Expr::mul(
                 Expr::zext(bit_width, lhs)?,
                 Expr::zext(bit_width, rhs.clone())?,
@@ -2393,7 +2393,7 @@ impl<'s> Semantics<'s> {
 
             let dst = self.operand_load(&mut block, &detail.operands[0])?;
 
-            let result = self.temp(dst.bits());
+            let result = self.temp(0, dst.bits());
 
             block.assign(
                 scalar("CF", 1),
@@ -2471,7 +2471,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let mut rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = self.temp(lhs.bits());
+            let result = self.temp(0, lhs.bits());
 
             if lhs.bits() != rhs.bits() {
                 rhs = Expr::sext(lhs.bits(), rhs)?;
@@ -2542,7 +2542,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let temp = self.temp(lhs.bits());
+            let temp = self.temp(0, lhs.bits());
 
             block.assign(
                 temp.clone(),
@@ -2595,7 +2595,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let temp = self.temp(lhs.bits());
+            let temp = self.temp(0, lhs.bits());
 
             block.assign(
                 temp.clone(),
@@ -2648,7 +2648,7 @@ impl<'s> Semantics<'s> {
             let dst = self.get_register(detail.operands[0].reg())?;
             let src = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let temp = self.temp(dst.bits());
+            let temp = self.temp(0, dst.bits());
 
             block.assign(
                 temp.clone(),
@@ -2703,7 +2703,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let temp = self.temp(lhs.bits());
+            let temp = self.temp(0, lhs.bits());
 
             block.assign(
                 temp.clone(),
@@ -2821,7 +2821,7 @@ impl<'s> Semantics<'s> {
                 expr_const(0xffffffff, src.bits()),
             )?;
 
-            let temp = self.temp(detail.operands[0].size as usize * 8);
+            let temp = self.temp(0, detail.operands[0].size as usize * 8);
 
             block.assign(temp.clone(), result0);
             block.assign(
@@ -2932,12 +2932,12 @@ impl<'s> Semantics<'s> {
                     8,
                     Expression::shr(rhs.clone(), expr_const(i as u64 * 8, lhs.bits()))?,
                 )?;
-                let temp = self.temp(8);
+                let temp = self.temp(0, 8);
                 block.assign(temp.clone(), Expression::sub(ll, rr)?);
                 temp_vars.push(temp);
             }
 
-            let result = self.temp(lhs.bits());
+            let result = self.temp(1, lhs.bits());
             block.assign(result.clone(), expr_const(0, lhs.bits()));
             for i in 0..temp_vars.len() {
                 block.assign(
@@ -3057,7 +3057,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = self.temp(lhs.bits());
+            let result = self.temp(0, lhs.bits());
             block.assign(result.clone(), expr_const(0, result.bits()));
             for i in 0..lhs.bits() / 16 {
                 let ll = Expression::and(
@@ -3104,7 +3104,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = self.temp(lhs.bits());
+            let result = self.temp(0, lhs.bits());
             block.assign(result.clone(), expr_const(0, result.bits()));
             for i in 0..lhs.bits() / 32 {
                 let ll = Expression::and(
@@ -3398,7 +3398,7 @@ impl<'s> Semantics<'s> {
 
             // Do the SAR
             let expr = Expr::or(expr, Expr::shr(lhs.clone(), rhs.clone())?)?;
-            let temp = self.temp(lhs.bits());
+            let temp = self.temp(0, lhs.bits());
             block.assign(temp.clone(), expr);
 
             // OF is the last bit shifted out
@@ -3462,7 +3462,7 @@ impl<'s> Semantics<'s> {
             let mut block = control_flow_graph.new_block()?;
 
             // get operands
-            let temp = self.temp(8);
+            let temp = self.temp(0, 8);
             block.load(temp.clone(), di.get()?);
             let expr = Expr::sub(al.get()?, temp.clone().into())?;
 
@@ -3528,7 +3528,7 @@ impl<'s> Semantics<'s> {
             let mut block = control_flow_graph.new_block()?;
 
             // get operands
-            let temp = self.temp(16);
+            let temp = self.temp(0, 16);
             block.load(temp.clone(), di.get()?);
             let expr = Expr::sub(ax.get()?, temp.clone().into())?;
 
@@ -3942,7 +3942,7 @@ impl<'s> Semantics<'s> {
                 rhs = Expr::sext(lhs.bits(), rhs)?;
             }
 
-            let result = self.temp(lhs.bits());
+            let result = self.temp(0, lhs.bits());
             block.assign(result.clone(), Expr::sub(lhs.clone(), rhs.clone())?);
 
             // calculate flags
@@ -4068,7 +4068,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let result = self.temp(lhs.bits());
+            let result = self.temp(0, lhs.bits());
 
             // perform addition
             block.assign(result.clone(), Expr::add(lhs.clone(), rhs.clone())?);
@@ -4102,7 +4102,7 @@ impl<'s> Semantics<'s> {
             let lhs = self.operand_load(&mut block, &detail.operands[0])?;
             let rhs = self.operand_load(&mut block, &detail.operands[1])?;
 
-            let tmp = self.temp(lhs.bits());
+            let tmp = self.temp(0, lhs.bits());
             block.assign(tmp.clone(), lhs.clone());
 
             self.operand_store(&mut block, &detail.operands[0], rhs)?;
@@ -4132,7 +4132,7 @@ impl<'s> Semantics<'s> {
                 rhs = Expr::sext(lhs.bits(), rhs)?;
             }
 
-            let result = self.temp(lhs.bits());
+            let result = self.temp(0, lhs.bits());
 
             // In the event lhs and rhs are the same, this is actually an
             // assignment of zero. Treat it as such.


### PR DESCRIPTION
This replaces the "unique temporary index per block" approach.

The unique temporary index per block is almost always 0 because
when lifting the instruction from Capstone to Falcon IL, each
lifted instruction results in a new CFG.

When merging the CFGs the temporary scalars are not adjusted,
therefore we end up with a lot of duplicated `temp_0.0` scalars
(which may have different bitness!).

This may cause problems when the CFG is manipulated and later
transformed into SSA.