### PR TITLE
Added scripts to get set up outside of docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 
 RUN apt-get update && \
     apt-get -y dist-upgrade && \
-    apt-get -y install wget && \
+    apt-get -y install wget apt-transport-https && \
     echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" >> /etc/apt/sources.list && \
     echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" >> /etc/apt/sources.list && \
     wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -2,7 +2,7 @@ FROM debian:stretch
  
 RUN apt-get update && \ 
     apt-get -y dist-upgrade && \ 
-    apt-get -y install curl gnupg2 && \ 
+    apt-get -y install curl gnupg2 apt-transport-https && \
     echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-4.0 main" >> /etc/apt/sources.list && \ 
     echo "deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch-4.0 main" >> /etc/apt/sources.list && \ 
     curl http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \ 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,11 @@
+#-*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "generic/debian9"  # Stretch
+  #config.vm.box = "ubuntu/bionic64"  # 18.04
+
+  config.vm.provision "file", source: "dependencies.sh", destination: "$HOME/dependencies.sh"
+  config.vm.provision "shell", path: "setup.sh", privileged: false
+end
+

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Script assumes the ability to run sudo without a password
+
+grep 'ID=debian' /etc/os-release
+if [ $? -eq 0 ]; then
+	grep 'VERSION_CODENAME=stretch' /etc/os-release
+	if [ $? -eq 0 ]; then
+		sudo DEBIAN_FRONTEND=noninteractive apt-get update
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y install curl gnupg2 apt-transport-https
+		echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-4.0 main" | sudo tee -a /etc/apt/sources.list
+		echo "deb-src http://apt.llvm.org/stretch/ llvm-toolchain-stretch-4.0 main" | sudo tee -a /etc/apt/sources.list
+		curl http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+		sudo DEBIAN_FRONTEND=noninteractive apt-get update
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential clang-4.0 curl llvm-4.0-dev \
+			libcapstone3 libcapstone-dev libclang-4.0-dev pkg-config
+		sudo DEBIAN_FRONTEND=noninteractive apt-get clean
+		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
+		#curl https://sh.rustup.rs -sSf > /tmp/install.sh
+		chmod +x rustup.sh
+		./rustup.sh -y
+	else
+		echo "Unsupported version of Debian"
+		exit 1
+	fi
+else
+	echo "Unsupported Distro"
+	exit 1
+fi
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+./dependencies.sh
+if [ $? -ne 0 ]; then
+	echo "Failed to install dependencies"
+	exit 1
+fi
+
+. $HOME/.cargo/env
+git clone https://github.com/falconre/falcon
+cd falcon
+cargo build
+cargo new falcontest
+cd falcontest
+echo 'falcon = { path = ".." }' >> Cargo.toml
+echo 'extern crate falcon;
+
+use falcon::loader::Elf;
+use falcon::loader::Loader;
+use std::path::Path;
+
+fn main() {
+    let elf = Elf::from_file(Path::new("/bin/sh")).unwrap();
+    for function in elf.program().unwrap().functions() {
+        for block in function.blocks() {
+            println!("Block {} in Function {:x}", block.index(), function.address());
+            println!("{}", block);
+        }
+    }
+}' > src/main.rs
+cargo build
+cargo run
+
+exit $?


### PR DESCRIPTION
I wanted the ability to run the code from within my VM, so I made a script to accomplish that.  I also made a Vagrantfile so it was easier for me to test my changes.  The setup.sh and dependencies.sh scripts can be used with Vagrant VMs, manually created VMs, physical machines, Docker images, etc.  The general goal of this PR is to make it easier for people to get a Falcon environment set up.