### PR TITLE
Graph: Optimize compute_predecessors

### DIFF
--- a/lib/graph/mod.rs
+++ b/lib/graph/mod.rs
@@ -525,32 +525,19 @@ where
         }
 
         // for every vertex
-        while !queue.is_empty() {
-            let vertex_index = queue.pop_front().unwrap();
+        while let Some(vertex_index) = queue.pop_front() {
+            let this_predecessors = predecessors.get(&vertex_index).unwrap().clone();
 
-            // for each predecessor of this vertex
-            let mut to_add: Vec<usize> = Vec::new();
-            {
-                let this_predecessors = &predecessors[&vertex_index];
-                for predecessor in &predecessors[&vertex_index] {
-                    // ensure each of this predecessor's predecessors are predecessors
-                    // of this vertex
-                    for pp in &predecessors[predecessor] {
-                        if !this_predecessors.contains(pp) {
-                            to_add.push(*pp);
-                        }
-                    }
+            for successor_index in &self.successors[&vertex_index] {
+                let successor_predecessors = predecessors.get_mut(&successor_index).unwrap();
+
+                let mut changed = false;
+                for predecessor in &this_predecessors {
+                    changed = changed | successor_predecessors.insert(*predecessor);
                 }
-            }
 
-            let this_predecessors = predecessors.get_mut(&vertex_index).unwrap();
-            for predecessor in &to_add {
-                this_predecessors.insert(*predecessor);
-            }
-
-            if !to_add.is_empty() {
-                for successor in &self.successors[&vertex_index] {
-                    queue.push_back(*successor);
+                if changed {
+                    queue.push_back(*successor_index);
                 }
             }
         }


### PR DESCRIPTION
During SSA transformation most of the run-time was spend in `compute_predecessors`. According to perf, the reason for this was the amount of hashing required in the algorithm.

The following graph shows the execution time of the SSA transformation for a small single-loop program. The control flow graph is obtained by unrolling the loop `k` times (roughly speaking: duplicating the loop body `k` times and adding additional CFG edges to obtain a loop-free program). The resulting CFG has  `8+k*2` basic blocks, meaning that we measure the execution time of the SSA transformation of `8+k*2` basic blocks.

![image](https://user-images.githubusercontent.com/6727923/77855530-4c564280-71f1-11ea-87ff-298721cccdd2.png)

For `k=150` the SSA transformation with the optimized `compute_predecessors` is about twice as fast as master.


