### PR TITLE
Graph: Use Semi-NCA algorithm in compute_immediate_dominators

### DIFF
--- a/lib/graph/mod.rs
+++ b/lib/graph/mod.rs
@@ -377,6 +377,33 @@ where
         Ok(reachable_vertices)
     }
 
+    /// Compute the pre order of all vertices in the graph
+    pub fn compute_pre_order(&self, root: usize) -> Result<Vec<usize>> {
+        if !self.has_vertex(root) {
+            bail!("vertex does not exist");
+        }
+
+        let mut visited: HashSet<usize> = HashSet::new();
+        let mut stack: Vec<usize> = Vec::new();
+        let mut order: Vec<usize> = Vec::new();
+
+        stack.push(root);
+
+        while let Some(node) = stack.pop() {
+            if !visited.insert(node) {
+                continue;
+            }
+
+            order.push(node);
+
+            for &successor in &self.successors[&node] {
+                stack.push(successor);
+            }
+        }
+
+        Ok(order)
+    }
+
     // Compute the post order of all vertices in the graph
     pub fn compute_post_order(&self, root: usize) -> Result<Vec<usize>> {
         let mut visited: HashSet<usize> = HashSet::new();
@@ -1043,6 +1070,15 @@ mod tests {
 
         // vertex 7 does not exist
         assert!(graph.successors(7).is_err());
+    }
+
+    #[test]
+    fn test_pre_order() {
+        let graph = create_test_graph();
+
+        assert_eq!(graph.compute_pre_order(1).unwrap(), vec![1, 2, 6, 4, 5, 3]);
+
+        assert_eq!(graph.compute_pre_order(5).unwrap(), vec![5, 2, 6, 4, 3]);
     }
 
     #[test]


### PR DESCRIPTION
The Semi-NCA algorithm is described in: Linear-Time Algorithms for Dominators and Related Problems https://www.cs.princeton.edu/research/techreps/TR-737-05

This algorithm drastically improves the performance of `compute_immediate_dominators` as shown in the following benchmark.

The graph shows the execution time of the SSA transformation (which requires the immediate dominators) for a small single-loop program. The control flow graph is obtained by unrolling the loop k times (roughly speaking: duplicating the loop body k times and adding additional CFG edges to obtain a loop-free program). The resulting CFG has `8+k*2` basic blocks, meaning that we measure the execution time of the SSA transformation of `8+k*2` basic blocks.

![image](https://user-images.githubusercontent.com/6727923/77856900-a4457700-71fa-11ea-85f9-c0859090dcf4.png)

For `k=150`:
* master takes about 52 seconds
* master + optimized predecessors (https://github.com/falconre/falcon/pull/76) takes about 20 seconds
* SEMI-NCA takes about 19 milliseconds