### PR TITLE
translator/x86: Fix rol/ror semantics

### DIFF
--- a/lib/translator/x86/semantics.rs
+++ b/lib/translator/x86/semantics.rs
@@ -3263,9 +3263,12 @@ impl<'s> Semantics<'s> {
             // CF is the bit sent from one end to the other. In our case, it should be MSB of result
             block.assign(
                 scalar("CF", 1),
-                Expr::shr(
-                    result.clone(),
-                    expr_const(result.bits() as u64 - 1, result.bits()),
+                Expr::trun(
+                    1,
+                    Expr::shr(
+                        result.clone(),
+                        expr_const(result.bits() as u64 - 1, result.bits()),
+                    )?,
                 )?,
             );
 

--- a/lib/translator/x86/semantics.rs
+++ b/lib/translator/x86/semantics.rs
@@ -3191,13 +3191,7 @@ impl<'s> Semantics<'s> {
             )?;
 
             // CF is the bit sent from one end to the other. In our case, it should be LSB of result
-            block.assign(
-                scalar("CF", 1),
-                Expr::shr(
-                    result.clone(),
-                    expr_const(result.bits() as u64 - 1, result.bits()),
-                )?,
-            );
+            block.assign(scalar("CF", 1), Expr::trun(1, result.clone())?);
 
             // OF is XOR of two most-significant bits of result
             block.assign(


### PR DESCRIPTION
* For both, `rol` and `ror`, the value assigned to `ZF` was more than one bit wide
* Replaced ZF shifting in `rol` by truncation (we are interested in the LSB instead of MSB)
