### PR TITLE
Add arithmetic shift right expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ default = ["capstone4"]
 thread_safe = []
 capstone4 = ["falcon_capstone/capstone4"]
 static = ["falcon_capstone/static"]
+il-expression-ashr = []
 
 [lib]
 name = "falcon"

--- a/lib/executor/eval.rs
+++ b/lib/executor/eval.rs
@@ -21,6 +21,7 @@ pub fn eval(expr: &il::Expression) -> Result<il::Constant> {
         il::Expression::Xor(ref lhs, ref rhs) => eval(lhs)?.xor(&eval(rhs)?)?,
         il::Expression::Shl(ref lhs, ref rhs) => eval(lhs)?.shl(&eval(rhs)?)?,
         il::Expression::Shr(ref lhs, ref rhs) => eval(lhs)?.shr(&eval(rhs)?)?,
+        il::Expression::AShr(ref lhs, ref rhs) => eval(lhs)?.ashr(&eval(rhs)?)?,
         il::Expression::Cmpeq(ref lhs, ref rhs) => eval(lhs)?.cmpeq(&eval(rhs)?)?,
         il::Expression::Cmpneq(ref lhs, ref rhs) => eval(lhs)?.cmpneq(&eval(rhs)?)?,
         il::Expression::Cmplts(ref lhs, ref rhs) => eval(lhs)?.cmplts(&eval(rhs)?)?,

--- a/lib/executor/eval.rs
+++ b/lib/executor/eval.rs
@@ -21,6 +21,7 @@ pub fn eval(expr: &il::Expression) -> Result<il::Constant> {
         il::Expression::Xor(ref lhs, ref rhs) => eval(lhs)?.xor(&eval(rhs)?)?,
         il::Expression::Shl(ref lhs, ref rhs) => eval(lhs)?.shl(&eval(rhs)?)?,
         il::Expression::Shr(ref lhs, ref rhs) => eval(lhs)?.shr(&eval(rhs)?)?,
+        #[cfg(feature = "il-expression-ashr")]
         il::Expression::AShr(ref lhs, ref rhs) => eval(lhs)?.ashr(&eval(rhs)?)?,
         il::Expression::Cmpeq(ref lhs, ref rhs) => eval(lhs)?.cmpeq(&eval(rhs)?)?,
         il::Expression::Cmpneq(ref lhs, ref rhs) => eval(lhs)?.cmpneq(&eval(rhs)?)?,

--- a/lib/executor/state.rs
+++ b/lib/executor/state.rs
@@ -99,6 +99,7 @@ impl State {
                 self.symbolize_expression(lhs)?,
                 self.symbolize_expression(rhs)?,
             )?,
+            #[cfg(feature = "il-expression-ashr")]
             il::Expression::AShr(ref lhs, ref rhs) => il::Expression::ashr(
                 self.symbolize_expression(lhs)?,
                 self.symbolize_expression(rhs)?,

--- a/lib/executor/state.rs
+++ b/lib/executor/state.rs
@@ -99,6 +99,10 @@ impl State {
                 self.symbolize_expression(lhs)?,
                 self.symbolize_expression(rhs)?,
             )?,
+            il::Expression::AShr(ref lhs, ref rhs) => il::Expression::ashr(
+                self.symbolize_expression(lhs)?,
+                self.symbolize_expression(rhs)?,
+            )?,
             il::Expression::Cmpeq(ref lhs, ref rhs) => il::Expression::cmpeq(
                 self.symbolize_expression(lhs)?,
                 self.symbolize_expression(rhs)?,

--- a/lib/il/constant.rs
+++ b/lib/il/constant.rs
@@ -287,6 +287,29 @@ impl Constant {
         }
     }
 
+    pub fn ashr(&self, rhs: &Constant) -> Result<Constant> {
+        if self.bits() != rhs.bits() {
+            Err(ErrorKind::Sort.into())
+        } else {
+            let r = rhs
+                .value
+                .to_usize()
+                .map(|bits| {
+                    let value = self.value() >> bits;
+                    let msb = self.value() >> (self.bits - 1);
+                    if msb.is_zero() {
+                        value
+                    } else {
+                        let all_one = BigUint::from_u64(u64::MAX).unwrap();
+                        let fill = all_one << (self.bits - bits);
+                        fill | value
+                    }
+                })
+                .unwrap_or_else(|| BigUint::from_u64(0).unwrap());
+            Ok(Constant::new_big(r, self.bits))
+        }
+    }
+
     pub fn cmpeq(&self, rhs: &Constant) -> Result<Constant> {
         if self.bits() != rhs.bits() {
             Err(ErrorKind::Sort.into())
@@ -477,6 +500,22 @@ fn constant_shr() {
     assert_eq!(
         Constant::new(0x100, 64).shr(&Constant::new(8, 64)).unwrap(),
         Constant::new(1, 64)
+    );
+}
+
+#[test]
+fn constant_ashr() {
+    assert_eq!(
+        Constant::new(0x40000000, 32)
+            .ashr(&Constant::new(0x10, 32))
+            .unwrap(),
+        Constant::new(0x00004000, 32)
+    );
+    assert_eq!(
+        Constant::new(0x80000000, 32)
+            .ashr(&Constant::new(0x10, 32))
+            .unwrap(),
+        Constant::new(0xffff8000, 32)
     );
 }
 

--- a/lib/il/expression.rs
+++ b/lib/il/expression.rs
@@ -43,6 +43,7 @@ pub enum Expression {
     Xor(Box<Expression>, Box<Expression>),
     Shl(Box<Expression>, Box<Expression>),
     Shr(Box<Expression>, Box<Expression>),
+    AShr(Box<Expression>, Box<Expression>),
 
     Cmpeq(Box<Expression>, Box<Expression>),
     Cmpneq(Box<Expression>, Box<Expression>),
@@ -73,7 +74,8 @@ impl Expression {
             | Expression::Or(ref lhs, _)
             | Expression::Xor(ref lhs, _)
             | Expression::Shl(ref lhs, _)
-            | Expression::Shr(ref lhs, _) => lhs.bits(),
+            | Expression::Shr(ref lhs, _)
+            | Expression::AShr(ref lhs, _) => lhs.bits(),
             Expression::Cmpeq(_, _)
             | Expression::Cmpneq(_, _)
             | Expression::Cmplts(_, _)
@@ -155,6 +157,9 @@ impl Expression {
                         Expression::Shr(ref lhs, ref rhs) => {
                             Expression::shr(self.map(lhs)?, self.map(rhs)?)?
                         }
+                        Expression::AShr(ref lhs, ref rhs) => {
+                            Expression::ashr(self.map(lhs)?, self.map(rhs)?)?
+                        }
                         Expression::Cmpeq(ref lhs, ref rhs) => {
                             Expression::cmpeq(self.map(lhs)?, self.map(rhs)?)?
                         }
@@ -216,6 +221,7 @@ impl Expression {
             | Expression::Xor(ref lhs, ref rhs)
             | Expression::Shl(ref lhs, ref rhs)
             | Expression::Shr(ref lhs, ref rhs)
+            | Expression::AShr(ref lhs, ref rhs)
             | Expression::Cmpeq(ref lhs, ref rhs)
             | Expression::Cmpneq(ref lhs, ref rhs)
             | Expression::Cmplts(ref lhs, ref rhs)
@@ -247,6 +253,7 @@ impl Expression {
             | Expression::Xor(ref lhs, ref rhs)
             | Expression::Shl(ref lhs, ref rhs)
             | Expression::Shr(ref lhs, ref rhs)
+            | Expression::AShr(ref lhs, ref rhs)
             | Expression::Cmpeq(ref lhs, ref rhs)
             | Expression::Cmpneq(ref lhs, ref rhs)
             | Expression::Cmplts(ref lhs, ref rhs)
@@ -286,6 +293,7 @@ impl Expression {
             | Expression::Xor(ref mut lhs, ref mut rhs)
             | Expression::Shl(ref mut lhs, ref mut rhs)
             | Expression::Shr(ref mut lhs, ref mut rhs)
+            | Expression::AShr(ref mut lhs, ref mut rhs)
             | Expression::Cmpeq(ref mut lhs, ref mut rhs)
             | Expression::Cmpneq(ref mut lhs, ref mut rhs)
             | Expression::Cmplts(ref mut lhs, ref mut rhs)
@@ -432,6 +440,15 @@ impl Expression {
     pub fn shr(lhs: Expression, rhs: Expression) -> Result<Expression> {
         Expression::ensure_sort(&lhs, &rhs)?;
         Ok(Expression::Shr(Box::new(lhs), Box::new(rhs)))
+    }
+
+    /// Create an arithmetic shift-right `Expression`.
+    /// # Error
+    /// The sort of the lhs and the rhs are not the same.
+    #[allow(clippy::should_implement_trait)]
+    pub fn ashr(lhs: Expression, rhs: Expression) -> Result<Expression> {
+        Expression::ensure_sort(&lhs, &rhs)?;
+        Ok(Expression::AShr(Box::new(lhs), Box::new(rhs)))
     }
 
     /// Create an equals comparison `Expression`.
@@ -589,6 +606,7 @@ impl fmt::Display for Expression {
             Expression::Xor(ref lhs, ref rhs) => write!(f, "({} ^ {})", lhs, rhs),
             Expression::Shl(ref lhs, ref rhs) => write!(f, "({} << {})", lhs, rhs),
             Expression::Shr(ref lhs, ref rhs) => write!(f, "({} >> {})", lhs, rhs),
+            Expression::AShr(ref lhs, ref rhs) => write!(f, "({} >>> {})", lhs, rhs),
             Expression::Cmpeq(ref lhs, ref rhs) => write!(f, "({} == {})", lhs, rhs),
             Expression::Cmpneq(ref lhs, ref rhs) => write!(f, "({} != {})", lhs, rhs),
             Expression::Cmplts(ref lhs, ref rhs) => write!(f, "({} <s {})", lhs, rhs),

--- a/lib/translator/mips/semantics.rs
+++ b/lib/translator/mips/semantics.rs
@@ -2064,17 +2064,7 @@ pub fn sra(control_flow_graph: &mut ControlFlowGraph, instruction: &capstone::In
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        // set up the mask to put the arithmetic in shift arithmetic right
-        let temp = Scalar::temp(instruction.address, 32);
-        let expr = Expr::shl(
-            Expr::sub(
-                expr_const(0, 32),
-                Expr::shr(rt.clone(), expr_const(31, 32))?,
-            )?,
-            Expr::sub(expr_const(32, 32), sa.clone())?,
-        )?;
-        block.assign(temp.clone(), expr);
-        block.assign(rd, Expr::or(Expr::shr(rt, sa)?, temp.into())?);
+        block.assign(rd, Expr::ashr(rt, sa)?);
 
         block.index()
     };
@@ -2099,17 +2089,7 @@ pub fn srav(
     let block_index = {
         let block = control_flow_graph.new_block()?;
 
-        // set up the mask to put the arithmetic in shift arithmetic right
-        let temp = Scalar::temp(instruction.address, 32);
-        let expr = Expr::shl(
-            Expr::sub(
-                expr_const(0, 32),
-                Expr::shr(rt.clone(), expr_const(31, 32))?,
-            )?,
-            Expr::sub(expr_const(32, 32), rs.clone())?,
-        )?;
-        block.assign(temp.clone(), expr);
-        block.assign(rd, Expr::or(Expr::shr(rt, rs)?, temp.into())?);
+        block.assign(rd, Expr::ashr(rt, rs)?);
 
         block.index()
     };

--- a/lib/translator/x86/semantics.rs
+++ b/lib/translator/x86/semantics.rs
@@ -3401,31 +3401,31 @@ impl<'s> Semantics<'s> {
                 rhs = Expr::zext(lhs.bits(), rhs)?;
             }
 
-            // Create the mask we apply if that lhs is signed
-            let mask = Expr::shl(expr_const(1, lhs.bits()), rhs.clone())?;
-            let mask = Expr::sub(mask, expr_const(1, lhs.bits()))?;
-            let mask = Expr::shl(
-                mask,
-                Expr::sub(expr_const(lhs.bits() as u64, lhs.bits()), rhs.clone())?,
-            )?;
-
-            // Multiple the mask by the sign bit
-            let expr = Expr::shr(lhs.clone(), expr_const(lhs.bits() as u64 - 1, lhs.bits()))?;
-            let expr = Expr::mul(mask, expr)?;
-
             // Do the SAR
-            let expr = Expr::or(expr, Expr::shr(lhs.clone(), rhs)?)?;
-            let temp = self.temp(0, lhs.bits());
-            block.assign(temp.clone(), expr);
+            let expr = Expr::ashr(lhs.clone(), rhs.clone())?;
+
+            // CF is the last bit shifted out
+            // This will give us a bit mask if rhs is not equal to zero
+            let non_zero_mask = Expr::sub(
+                expr_const(0, rhs.bits()),
+                Expr::zext(
+                    rhs.bits(),
+                    Expr::cmpneq(rhs.clone(), expr_const(0, rhs.bits()))?,
+                )?,
+            )?;
+            // This shifts lhs right by (rhs - 1)
+            let cf = Expr::shr(lhs, Expr::sub(rhs.clone(), expr_const(1, rhs.bits()))?)?;
+            // Apply mask
+            let cf = Expr::trun(1, Expr::and(cf, non_zero_mask)?)?;
+            block.assign(scalar("CF", 1), cf);
 
             // OF is the last bit shifted out
             block.assign(scalar("OF", 1), expr_const(0, 1));
 
-            self.set_zf(&mut block, temp.clone().into())?;
-            self.set_sf(&mut block, temp.clone().into())?;
-            self.set_cf(&mut block, temp.clone().into(), lhs)?;
+            self.set_zf(&mut block, expr.clone())?;
+            self.set_sf(&mut block, expr.clone())?;
 
-            self.operand_store(&mut block, &detail.operands[0], temp.into())?;
+            self.operand_store(&mut block, &detail.operands[0], expr)?;
 
             block.index()
         };


### PR DESCRIPTION
This change is motivated by the fact, that SMT solvers have builtin support for arithmetic shift right which is more efficient than the combination of shl, sub and shr.